### PR TITLE
Fix row cloning bug

### DIFF
--- a/docx/table.go
+++ b/docx/table.go
@@ -237,7 +237,9 @@ func (row *TableRow) Clone() *TableRow {
     result := new(TableRow)
     result.Params = row.Params
     result.OtherParams = new(TableParamsEx)
-    result.OtherParams.Shadow = row.OtherParams.Shadow
+    if row.OtherParams != nil {
+        result.OtherParams.Shadow = row.OtherParams.Shadow
+    }
     // Клонируем ячейки
     result.Cells = make([]*TableCell, 0)
     for _, cell := range row.Cells {

--- a/docx/template.go
+++ b/docx/template.go
@@ -45,6 +45,8 @@ func renderTemplateHeader(header *Header, v interface{}) error {
 
 
 // Поиск элементов шаблона и спаивания текстовых элементов
+// Note: This merge text in one tag and leaves styles only from first element
+// Pseudo example: <red>Red<red><blue>Blue</blue> --> <red>RedBlue</red>
 func findTemplatePatternsInParagraph(p *ParagraphItem) {
     if p != nil {
         // Перебор элементов параграфа и поиск начал {{ и конца }}                
@@ -82,7 +84,7 @@ func renderDocItem(item DocItem, v interface{}) error {
     switch elem := item.(type) {
         // Параграф
         case *ParagraphItem: {
-            findTemplatePatternsInParagraph(elem)
+            //findTemplatePatternsInParagraph(elem)
             for _, i := range elem.Items {
                 if err := renderDocItem(i, v); err != nil {
                     return err


### PR DESCRIPTION
`error: invalid memory address or nil pointer dereference` on cloning row with no Shadow property.